### PR TITLE
docs: add missing workon command to Linux build instructions

### DIFF
--- a/requirement-and-installation/build-from-source.md
+++ b/requirement-and-installation/build-from-source.md
@@ -28,6 +28,7 @@ Create a new [virtual environment](http://docs.python-guide.org/en/latest/dev/vi
 
 ```sh
 mkvirtualenv rotki -p /usr/bin/python3.11
+workon rotki
 ```
 
 Then install all the Python requirements:


### PR DESCRIPTION
workon is required on Linux for activating a virtualenv, just like it is on MacOS.  It's already documented in the MacOS section, so include it in the Linux section too.