### PR TITLE
link to `develop_data` directory info from `data-directory.md`

### DIFF
--- a/usage-guides/data-directory.md
+++ b/usage-guides/data-directory.md
@@ -9,3 +9,9 @@ rotki saves user data by default in a different directory per OS. For each OS, d
 Before v1.6.0, rotki was saving data in `$USER/.rotkehlchen`. From v1.6.0, that directory got migrated to the OS equivalent standard directory, and it should be safe for users to delete the old directory as long as the new directory contains the migrated DB.
 
 A very good idea for the rotki data directory would be to make frequent backups of it as it contains all of the data of all of your rotki accounts and cache data for historical price queries.
+
+## Data directory for unreleased development code
+
+If you are running rotki from unreleased code from git branches,
+please note that [the data directory is in a slightly different
+location](../contribution-guides/contribute-as-developer.html#working-with-the-develop-branch).


### PR DESCRIPTION
Currently the `data-directory.md` page doesn't mention the exception where `develop_data` is used for non-production environments.  So add a link to that information to make it easier for the reader to find.