### PR TITLE
docs: add LLMs page and fix LLM copy button issues

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -260,6 +260,12 @@ export default defineConfig({
         ],
       },
       {
+        text: 'AI Tools',
+        items: [
+          { text: 'LLMs', link: '/llms' },
+        ],
+      },
+      {
         text: 'Contribution Guides',
         items: [
           { text: 'Bug Reporting', link: '/contribution-guides/' },
@@ -303,7 +309,7 @@ export default defineConfig({
   },
   vite: {
     plugins: [
-      llmstxt({ ignoreFiles: getRedirectPaths(redirects) }),
+      llmstxt({ ignoreFiles: [...getRedirectPaths(redirects), 'llms.md'] }),
       redirectsPlugin({ redirects, base }),
     ],
     resolve: {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -309,7 +309,10 @@ export default defineConfig({
   },
   vite: {
     plugins: [
-      llmstxt({ ignoreFiles: [...getRedirectPaths(redirects), 'llms.md'] }),
+      llmstxt({
+        ignoreFiles: [...getRedirectPaths(redirects), 'llms.md'],
+        excludeIndexPage: false,
+      }),
       redirectsPlugin({ redirects, base }),
     ],
     resolve: {

--- a/index.md
+++ b/index.md
@@ -8,12 +8,23 @@ rotki is an open-source asset management and accounting application specializing
 
 ## Where to start?
 
+<llm-exclude>
 <NavCards :cards="[
   { icon: '📦', title: 'Installation Guide', description: 'Download and install rotki on Linux, macOS, or Windows.', link: '/requirement-and-installation/' },
   { icon: '🚀', title: 'Quick Start Guide', description: 'Step-by-step walkthrough from installation to your first PnL report.', link: '/usage-guides/quick-start' },
   { icon: '📊', title: 'Tax Accounting Guide', description: 'Step-by-step walkthrough from setup to generating your PnL report.', link: '/usage-guides/tax-accounting/guide' },
   { icon: '🤝', title: 'Contribution Guide', description: 'Report bugs, request features, or contribute code to rotki.', link: '/contribution-guides/' },
 ]" />
+</llm-exclude>
+
+<llm-only>
+
+- [Installation Guide](/requirement-and-installation/): Download and install rotki on Linux, macOS, or Windows.
+- [Quick Start Guide](/usage-guides/quick-start): Step-by-step walkthrough from installation to your first PnL report.
+- [Tax Accounting Guide](/usage-guides/tax-accounting/guide): Step-by-step walkthrough from setup to generating your PnL report.
+- [Contribution Guide](/contribution-guides/): Report bugs, request features, or contribute code to rotki.
+
+</llm-only>
 
 ## Disclaimer
 

--- a/llms.md
+++ b/llms.md
@@ -1,0 +1,45 @@
+# Using LLMs
+
+rotki's documentation is available in LLM-friendly formats to help developers and AI agents integrate with rotki faster.
+
+## Available Endpoints
+
+| Endpoint                        | Description                                                        |
+| ------------------------------- | ------------------------------------------------------------------ |
+| [llms.txt](/llms.txt)           | Curated index of all pages with one-line descriptions. Start here. |
+| [llms-full.txt](/llms-full.txt) | All pages in clean markdown, organized by section.                 |
+
+Each documentation page also has an individual `.md` version available for LLMs (use the "Copy page for LLMs" button on any page).
+
+## Which file should I use?
+
+- **Quick lookup** — Use `llms.txt` to find the right page, then fetch it individually.
+- **Full context** — Use `llms-full.txt` for complete documentation in a single file. Best for comprehensive context.
+
+## Using with AI Code Editors
+
+### Cursor
+
+Add the following URL to **Cursor Settings > Features > Docs**:
+
+```
+https://docs.rotki.com/llms-full.txt
+```
+
+### Claude Code
+
+To give Claude Code access to the rotki documentation, you can fetch it directly:
+
+```bash
+curl -s https://docs.rotki.com/llms-full.txt
+```
+
+Or reference specific pages:
+
+```bash
+curl -s https://docs.rotki.com/usage-guides.md
+```
+
+### Other Tools
+
+Any tool that supports the [llms.txt standard](https://llmstxt.org/) can consume rotki's documentation. Point it to `https://docs.rotki.com/llms.txt` as the entry point.


### PR DESCRIPTION
## Summary

- Add a dedicated "Using LLMs" page documenting available LLM-friendly endpoints (`llms.txt`, `llms-full.txt`, per-page `.md`) with usage instructions for Cursor, Claude Code, and other tools.
- Fix root page "Copy page for LLMs" returning 404 by setting `excludeIndexPage: false` so `index.md` is generated.
- Add `<llm-only>` / `<llm-exclude>` tags to `index.md` so the `<NavCards>` Vue component is replaced with plain markdown links in the LLM output.

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Visit `/llms` page and verify it renders correctly
- [ ] Click "Copy page for LLMs" on the root page and verify markdown is returned (not 404 or HTML)
- [ ] Verify `/llms.txt` and `/llms-full.txt` still generate correctly
- [ ] Verify the LLMs page itself is excluded from `llms.txt`