### PR TITLE
docs: recommend locked uv

### DIFF
--- a/contribution-guides/code-profiling.md
+++ b/contribution-guides/code-profiling.md
@@ -13,7 +13,7 @@ To use the flamegraph profiler, follow these steps:
 1. Install the latest dependencies required for profiling:
 
    ```sh
-   uv sync --group profiling
+   uv sync --locked --group profiling
    ```
 
 2. Install the [flamegraph](https://github.com/brendangregg/FlameGraph) package in your system. Some OSes, such as Archlinux, have [ready-made packages](https://aur.archlinux.org/packages/flamegraph/).

--- a/requirement-and-installation/build-from-source.md
+++ b/requirement-and-installation/build-from-source.md
@@ -33,7 +33,7 @@ This guide assumes you checked out the `develop` branch, which is the default fo
 
 ## Backend setup
 
-The backend setup is the same across Linux, macOS, and Windows — install `uv`, then run `uv sync` to create the development environment. OS-specific notes are below.
+The backend setup is the same across Linux, macOS, and Windows — install `uv`, then run `uv sync --locked` to create the development environment. OS-specific notes are below.
 
 ### Install uv
 
@@ -54,7 +54,7 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 From the rotki repo root:
 
 ```sh
-uv sync --group dev --group lint
+uv sync --locked --group dev --group lint
 ```
 
 This creates a `.venv` and installs the backend, dev, and lint dependency groups.
@@ -145,7 +145,7 @@ To build a distributable package for your platform:
 
 ```sh
 # Install packaging dependencies
-uv sync --group packaging
+uv sync --locked --group packaging
 
 # Run the packaging script (works on all platforms)
 uv run python ./package.py --build full


### PR DESCRIPTION
 - It installs from uv.lock                                                                                                                                                                                                                                                       
 - It refuses to update uv.lock                                                                                                                                                                                                                                                   
 - It fails if pyproject.toml and uv.lock are inconsistent                                                                                                                                                                                                                        
 - It protects you from silently using a stale lockfile      