### PR TITLE
docs: fix two dead links

### DIFF
--- a/contribution-guides/contribute-as-developer.md
+++ b/contribution-guides/contribute-as-developer.md
@@ -146,9 +146,7 @@ As an example of how to add a new CEX you can check the [Bitpanda PR](https://gi
 
 ### Add Location
 
-You should add a new value to the [location Enum](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotke
-
-hlchen/types.py#L387) and also make sure that the value is mirrored in the DB's schema as seen [here](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/db/schema.py#L93-L94). Add it also in the `SUPPORTED_EXCHANGES` list [here](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/exchanges/manager.py#L31). Finally, don't forget to add it in the latest DB upgrade as seen in the Bitpanda PR linked at the start of this section.
+You should add a new value to the [location Enum](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/types.py#L387) and also make sure that the value is mirrored in the DB's schema as seen [here](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/db/schema.py#L93-L94). Add it also in the `SUPPORTED_EXCHANGES` list [here](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/exchanges/manager.py#L31). Finally, don't forget to add it in the latest DB upgrade as seen in the Bitpanda PR linked at the start of this section.
 
 ### Create exchange module
 

--- a/usage-guides/advanced/mobile.md
+++ b/usage-guides/advanced/mobile.md
@@ -8,7 +8,7 @@ If you are using DAppNode or the Docker image instead of the Electron applicatio
 
 ## DAppNode
 
-If you are running rotki on a DAppNode, then in order to access rotki on mobile the only thing needed is to set up a [VPN connection](https://docs.dappnode.io/user-guide/ui/access/vpn/) between DAppNode and your phone or tablet.
+If you are running rotki on a DAppNode, then in order to access rotki on mobile the only thing needed is to set up a [VPN connection](https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/overview/) between DAppNode and your phone or tablet.
 
 You can use either Wireguard or OpenVPN by following the guide linked above. When you are done with the configuration, you can activate the VPN connection on your device. With the VPN activated, you will be able to access rotki on `http://rotki.dappnode`.
 


### PR DESCRIPTION
Follow-up to #128. A dead-link crawl over the built site surfaced two genuine broken external links (both pre-existing, unrelated to the VitePress upgrade):

- **`contribute-as-developer`** — the *location Enum* link's URL was split across a blank line in the markdown source, so it rendered with a truncated href (`.../rotke`) and the remainder as literal text. Rejoined into a single valid URL (verified 200).
- **`mobile`** — the DAppNode VPN link pointed at `/user-guide/ui/access/vpn/`, which now 404s. Updated to the current docs URL `https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/overview/` (verified 200).

### Crawl summary
132 unique external URLs checked, 127 OK. The other 3 flags were false positives and left as-is: `defillama.com/pro-api` (403 Cloudflare bot-block), and two `min-api.cryptocompare.com/data/pricehistorical?...` example API URLs (401 — illustrative, require an API key).