### PR TITLE
docs: fix Bing crawler duplicate-title, short-description, and missing-alt warnings

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -98,7 +98,21 @@ const __dirname = path.dirname(fileURLToPath(new URL(import.meta.url)));
 const DOCS_VERSION = process.env.DOCS_VERSION;
 const isLatest = DOCS_VERSION === 'latest';
 const isPatch = DOCS_VERSION === 'patch';
-const base = isLatest || isPatch ? `/${DOCS_VERSION}` : '/';
+const isPreview = isLatest || isPatch;
+const base = isPreview ? `/${DOCS_VERSION}` : '/';
+
+const STABLE_HOSTNAME = 'https://docs.rotki.com';
+
+// Map a source file's relativePath to its canonical URL on the stable site,
+// matching VitePress' own output paths (no clean URLs: `index.md` -> dir, the
+// rest -> `.html`). The preview builds share the same sources as stable, so the
+// canonical always points back to the stable equivalent.
+function stableCanonical(relativePath: string): string {
+  const pathPart = relativePath
+    .replace(/(?:^|\/)index\.md$/, match => match.slice(0, -'index.md'.length))
+    .replace(/\.md$/, '.html');
+  return `${STABLE_HOSTNAME}/${pathPart}`;
+}
 
 // Version switcher entries. The current build is shown as the dropdown label;
 // the other two are listed as cross-links so every build — including the
@@ -119,8 +133,20 @@ export default defineConfig({
   // Only emit a sitemap for the canonical stable build (base '/'). The versioned
   // 'latest'/'patch' builds are previews and must not publish a competing sitemap.
   sitemap: base === '/'
-    ? { hostname: 'https://docs.rotki.com' }
+    ? { hostname: STABLE_HOSTNAME }
     : undefined,
+  // The 'latest'/'patch' previews render the same pages as stable, which Bing
+  // flags as duplicate titles/content across the three URL trees. Tell crawlers
+  // not to index the previews and point every preview page at its stable twin.
+  transformPageData(pageData) {
+    if (!isPreview)
+      return;
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push(
+      ['meta', { name: 'robots', content: 'noindex, follow' }],
+      ['link', { rel: 'canonical', href: stableCanonical(pageData.relativePath) }],
+    );
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: '/logo.png',

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -159,7 +159,7 @@ export default defineConfig({
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
-    logo: '/logo.png',
+    logo: { src: '/logo.png', alt: 'rotki' },
     nav: [
       { text: 'Documentation', link: '/' },
       { text: 'Download', link: 'https://rotki.com/download' },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -104,13 +104,13 @@ const base = isPreview ? `/${DOCS_VERSION}` : '/';
 const STABLE_HOSTNAME = 'https://docs.rotki.com';
 
 // Map a source file's relativePath to its canonical URL on the stable site,
-// matching VitePress' own output paths (no clean URLs: `index.md` -> dir, the
-// rest -> `.html`). The preview builds share the same sources as stable, so the
-// canonical always points back to the stable equivalent.
+// matching VitePress' clean-URL output (`index.md` -> directory, everything
+// else -> extensionless). The preview builds share the same sources as stable,
+// so the canonical always points back to the stable equivalent.
 function stableCanonical(relativePath: string): string {
   const pathPart = relativePath
     .replace(/(?:^|\/)index\.md$/, match => match.slice(0, -'index.md'.length))
-    .replace(/\.md$/, '.html');
+    .replace(/\.md$/, '');
   return `${STABLE_HOSTNAME}/${pathPart}`;
 }
 
@@ -130,22 +130,32 @@ export default defineConfig({
   title: 'rotki Documentation',
   base,
   description: 'All you need to start using rotki, or contributing to it.',
+  // Serve extensionless URLs (/foo, not /foo.html). Keeps internal links, the
+  // sitemap, and the canonical tags all on a single clean form so crawlers stop
+  // treating /foo and /foo.html as two separate, duplicate pages.
+  cleanUrls: true,
   // Only emit a sitemap for the canonical stable build (base '/'). The versioned
   // 'latest'/'patch' builds are previews and must not publish a competing sitemap.
   sitemap: base === '/'
     ? { hostname: STABLE_HOSTNAME }
     : undefined,
-  // The 'latest'/'patch' previews render the same pages as stable, which Bing
-  // flags as duplicate titles/content across the three URL trees. Tell crawlers
-  // not to index the previews and point every preview page at its stable twin.
+  // Bing flags duplicate titles/content from two sources: GitHub Pages serves
+  // every page at both `/foo` and `/foo.html`, and the 'latest'/'patch'
+  // previews re-render the same pages under their own URL trees. Emit a
+  // self-referencing canonical on every build (pointing at the one clean stable
+  // URL, matching the sitemap) so the `/foo` vs `/foo.html` pair collapses; on
+  // previews the same canonical points back to the stable twin. Previews
+  // additionally carry noindex so they drop out of the index entirely.
   transformPageData(pageData) {
-    if (!isPreview)
-      return;
     pageData.frontmatter.head ??= [];
     pageData.frontmatter.head.push(
-      ['meta', { name: 'robots', content: 'noindex, follow' }],
       ['link', { rel: 'canonical', href: stableCanonical(pageData.relativePath) }],
     );
+    if (isPreview) {
+      pageData.frontmatter.head.push(
+        ['meta', { name: 'robots', content: 'noindex, follow' }],
+      );
+    }
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/contribution-guides/code-profiling.md
+++ b/contribution-guides/code-profiling.md
@@ -1,5 +1,5 @@
 ---
-description: Profiling rotki Python code using flamegraphs and viztracer to identify performance bottlenecks.
+description: Profile rotki's Python code using flamegraphs and viztracer to find performance bottlenecks, with step-by-step instructions for running each profiler.
 ---
 
 # Code Profiling

--- a/contribution-guides/docker-publishing.md
+++ b/contribution-guides/docker-publishing.md
@@ -1,5 +1,5 @@
 ---
-description: Manual steps for building and publishing multi-architecture rotki Docker images to Docker Hub.
+description: Manually build and publish rotki's multi-architecture Docker images to Docker Hub, covering the full release steps for pushing the images to hub.docker.com.
 ---
 
 # Docker Publishing (Manual)

--- a/contribution-guides/feature-requests.md
+++ b/contribution-guides/feature-requests.md
@@ -1,5 +1,5 @@
 ---
-description: How to submit feature requests for rotki using the GitHub issue template.
+description: How to submit a feature request for rotki using the GitHub issue template, so the team can review, discuss, and prioritize your suggested improvements.
 ---
 
 # Feature Requests

--- a/contribution-guides/index.md
+++ b/contribution-guides/index.md
@@ -1,5 +1,5 @@
 ---
-description: How to contribute to rotki including bug reporting, debug mode, feature requests, and development setup.
+description: "How to contribute to rotki: reporting bugs, running it in debug mode, submitting feature requests, and setting up your environment for development."
 ---
 
 # rotki Contribution Guide

--- a/contribution-guides/manual-testing.md
+++ b/contribution-guides/manual-testing.md
@@ -1,5 +1,5 @@
 ---
-description: Manual testing checklist for rotki release binaries covering startup, trades, imports, and exchanges.
+description: Manual testing checklist for rotki release binaries, covering startup, external trades, data imports, exchanges, settings, balances, and tax reports.
 ---
 
 # Manual Testing

--- a/contribution-guides/python-testing.md
+++ b/contribution-guides/python-testing.md
@@ -1,5 +1,5 @@
 ---
-description: Running the Python test suite, linting with ruff/mypy/pylint, and mocking network calls in tests.
+description: Run rotki's Python test suite, lint with ruff, mypy, and pylint, mock network calls, and record HTTP interactions with VCR for fast, deterministic tests.
 ---
 
 # Python Code Testing

--- a/contribution-guides/releasing.md
+++ b/contribution-guides/releasing.md
@@ -1,5 +1,5 @@
 ---
-description: How rotki releases are cut, both minor (1.x.0) from develop and patch (1.x.y) from bugfixes.
+description: "How rotki releases are cut from its long-lived branches: minor 1.x.0 releases from develop and patch 1.x.y releases from bugfixes, step by step."
 ---
 
 # Releasing rotki

--- a/contribution-guides/rotki-database.md
+++ b/contribution-guides/rotki-database.md
@@ -1,5 +1,5 @@
 ---
-description: Architecture of rotki's SQLite databases, schema upgrades, data migrations, and cache management.
+description: Architecture of rotki's two SQLite databases (global.db and the user DB), how schema upgrades and data migrations run, and how cached data is managed.
 ---
 
 # rotki Database

--- a/contribution-guides/vue-typescript.md
+++ b/contribution-guides/vue-typescript.md
@@ -1,5 +1,5 @@
 ---
-description: Running Vue/TypeScript unit tests with vitest and end-to-end tests with Playwright for the rotki frontend.
+description: "Testing and maintaining the rotki frontend: unit tests with Vitest, end-to-end tests with Playwright, linting, and Vue/TypeScript code organization."
 ---
 
 # Vue/TypeScript

--- a/contribution-guides/working-on-issues.md
+++ b/contribution-guides/working-on-issues.md
@@ -1,5 +1,5 @@
 ---
-description: Workflow for picking up issues, opening PRs, and coordinating between backend and frontend teams.
+description: The rotki contributor workflow for picking up issues, opening pull requests, writing changelog entries, and finalizing work across the backend and frontend.
 ---
 
 # Working on issues

--- a/contribution-guides/working-with-frontend.md
+++ b/contribution-guides/working-with-frontend.md
@@ -1,5 +1,5 @@
 ---
-description: Frontend development setup including editor integration, environment variables, and development proxy config.
+description: "Set up rotki frontend development: editor integration, environment variables, the development proxy, running multiple instances, linting, and type checks."
 ---
 
 # Working with the Frontend

--- a/faq.md
+++ b/faq.md
@@ -1,5 +1,5 @@
 ---
-description: Frequently asked questions about rotki, premium subscriptions, supported exchanges, and common issues.
+description: Frequently asked questions about rotki covering the application, premium subscriptions, supported exchanges, roadmap, and solutions to common issues.
 ---
 
 # Frequently Asked Questions

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-description: Documentation for rotki, an open-source crypto portfolio tracker and tax reporting tool.
+description: rotki is an open-source, privacy-focused crypto portfolio tracker, analytics, and tax reporting app that runs locally. Start here to learn what it does.
 ---
 
 # What is rotki?

--- a/llms.md
+++ b/llms.md
@@ -1,3 +1,7 @@
+---
+description: rotki's documentation in LLM-friendly formats (llms.txt and Markdown) to help developers and AI coding agents integrate with rotki faster.
+---
+
 # Using LLMs
 
 rotki's documentation is available in LLM-friendly formats to help developers and AI agents integrate with rotki faster.

--- a/premium/api-keys.md
+++ b/premium/api-keys.md
@@ -1,5 +1,5 @@
 ---
-description: Creating, managing, and securing rotki premium API key and secret credentials for app activation.
+description: Create, manage, and secure the rotki premium API key and secret credentials used to activate your subscription in the app, with security best practices.
 ---
 
 # API Credentials

--- a/premium/devices.md
+++ b/premium/devices.md
@@ -1,5 +1,5 @@
 ---
-description: Managing devices connected to your rotki premium subscription and understanding per-tier device limits.
+description: Manage the devices connected to your rotki premium subscription, rename or remove them, and understand the per-tier device limits and registration rules.
 ---
 
 # Device Management

--- a/premium/index.md
+++ b/premium/index.md
@@ -1,5 +1,5 @@
 ---
-description: Overview of rotki premium subscription tiers, features, and how to get started with premium.
+description: "Discover rotki premium: paid subscription tiers that unlock extra features, how to get started, and how to manage it while supporting ongoing development."
 ---
 
 # Premium Overview

--- a/premium/payment-methods.md
+++ b/premium/payment-methods.md
@@ -1,5 +1,5 @@
 ---
-description: Managing saved credit/debit cards and setting default payment methods for rotki premium renewals.
+description: Add, view, and remove saved credit and debit cards for rotki premium, set a default payment method, and update card details used for renewals.
 ---
 
 # Payment Methods

--- a/premium/payment.md
+++ b/premium/payment.md
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step guide to purchasing a rotki premium subscription including plan selection and payment.
+description: "Purchase a rotki premium subscription step by step: select a plan, apply a discount or referral code, choose a payment method, and activate it in the app."
 ---
 
 # Payment Process

--- a/premium/plans-and-pricing.md
+++ b/premium/plans-and-pricing.md
@@ -1,5 +1,5 @@
 ---
-description: Comparing rotki premium subscription tiers, billing cycles, and choosing the right plan.
+description: Compare rotki premium subscription tiers and limits, understand billing cycles and custom plans, and choose or upgrade to the plan that fits your needs.
 ---
 
 # Plans & Pricing

--- a/premium/referrals.md
+++ b/premium/referrals.md
@@ -1,5 +1,5 @@
 ---
-description: Creating and using rotki premium referral codes for discounts on first subscriptions.
+description: Create and share rotki premium referral codes so both you and the people you refer earn a discount on their first subscription, plus troubleshooting.
 ---
 
 # Referral Program

--- a/premium/subscription.md
+++ b/premium/subscription.md
@@ -1,5 +1,5 @@
 ---
-description: Managing your rotki premium subscription, viewing payment history, canceling, and renewing plans.
+description: "Manage your rotki premium subscription: view details and payment history, access API keys, create referral codes, change your plan, cancel, or renew."
 ---
 
 # Subscription Management

--- a/requirement-and-installation/download.md
+++ b/requirement-and-installation/download.md
@@ -1,5 +1,5 @@
 ---
-description: Download and install rotki on Linux, macOS, or Windows using the official pre-built binaries.
+description: Download and install rotki on Linux, macOS, or Windows from the official pre-built binaries, with first-launch tips and troubleshooting for each platform.
 ---
 
 # Download & Install

--- a/requirement-and-installation/index.md
+++ b/requirement-and-installation/index.md
@@ -1,5 +1,5 @@
 ---
-description: Install rotki from pre-built binaries, run it in Docker, or build from source.
+description: "Get started with rotki: install from pre-built binaries, run it in Docker, or build from source, plus the system requirements you need to run it locally."
 ---
 
 # Installation

--- a/usage-guides/advanced/backend-config.md
+++ b/usage-guides/advanced/backend-config.md
@@ -1,5 +1,5 @@
 ---
-description: Customizing rotki backend arguments via rotki_config.json for log levels, data directories, and more.
+description: Customize the rotki Python backend through rotki_config.json, setting log levels, the data directory, and other arguments useful for debugging and tuning.
 ---
 
 # Set the backend's arguments

--- a/usage-guides/advanced/data-directory.md
+++ b/usage-guides/advanced/data-directory.md
@@ -1,5 +1,5 @@
 ---
-description: Default rotki data directory locations on Linux, macOS, and Windows, plus backup recommendations.
+description: Find rotki's default data directory on Linux, macOS, and Windows, learn where development builds store their data, and get recommendations for backing it up.
 ---
 
 # rotki data directory

--- a/usage-guides/advanced/database-access.md
+++ b/usage-guides/advanced/database-access.md
@@ -1,5 +1,5 @@
 ---
-description: How to open and query the encrypted rotki SQLite database using DB Browser for SQLite or sqlcipher CLI.
+description: Open and query rotki's encrypted SQLite database manually using DB Browser for SQLite or the sqlcipher CLI tool to inspect or repair your stored data.
 ---
 
 # Accessing the database manually

--- a/usage-guides/advanced/mobile.md
+++ b/usage-guides/advanced/mobile.md
@@ -1,5 +1,5 @@
 ---
-description: Accessing rotki from a mobile device using DAppNode VPN or Docker with an authenticated proxy.
+description: Access rotki from a mobile device when running it via DAppNode or the Docker image, using a VPN or an authenticated reverse proxy to reach the web interface.
 ---
 
 # Using rotki from mobile

--- a/usage-guides/advanced/troubleshooting.md
+++ b/usage-guides/advanced/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-description: Fixing common rotki issues such as login errors, frontend settings corruption, and data problems.
+description: Fix common rotki problems such as invalid input errors on login, corrupted frontend settings, and other data issues, with step-by-step recovery instructions.
 ---
 
 # Troubleshooting

--- a/usage-guides/data-management/address-book.md
+++ b/usage-guides/data-management/address-book.md
@@ -1,5 +1,5 @@
 ---
-description: Managing global and private address book entries to replace blockchain addresses with human-readable names.
+description: Manage global and private address book entries in rotki to replace blockchain addresses with readable names, and import multiple address books from CSV.
 ---
 
 # Address Book

--- a/usage-guides/data-management/assets.md
+++ b/usage-guides/data-management/assets.md
@@ -1,5 +1,5 @@
 ---
-description: Managing supported assets, adding custom tokens, merging duplicates, and whitelisting spam tokens.
+description: "Manage rotki's supported assets: inspect the asset list, add custom tokens, fix missing mappings, merge duplicates, and ignore or whitelist spam tokens."
 ---
 
 # Assets Management

--- a/usage-guides/data-management/prices.md
+++ b/usage-guides/data-management/prices.md
@@ -1,5 +1,5 @@
 ---
-description: Adding manual latest and historical prices, and editing oracle-cached prices for assets.
+description: Add manual latest and historical prices that override oracle lookups in rotki, and view or edit the prices already fetched and cached from price oracles.
 ---
 
 # Managing prices

--- a/usage-guides/data-management/tags.md
+++ b/usage-guides/data-management/tags.md
@@ -1,5 +1,5 @@
 ---
-description: Creating and editing tags with custom labels, descriptions, and colors for organizing accounts and balances.
+description: Create and edit tags in rotki with custom labels, descriptions, and colors to organize and filter your blockchain accounts and manual balances.
 ---
 
 # Tag Management

--- a/usage-guides/history/events.md
+++ b/usage-guides/history/events.md
@@ -1,5 +1,5 @@
 ---
-description: Browsing, filtering, decoding, and editing historical events from exchanges and blockchains.
+description: Browse, filter, decode, and edit historical events from exchanges and blockchains in rotki, redecode transactions, add events by hash, and export them to CSV.
 ---
 
 # History events

--- a/usage-guides/history/import-data.md
+++ b/usage-guides/history/import-data.md
@@ -1,5 +1,5 @@
 ---
-description: Importing trade and transaction data from CSV files exported by exchanges into rotki.
+description: Import trades and transactions into rotki from exchange CSV exports or the generic import format, so your full history is tracked even without API access.
 ---
 
 # Import CSV

--- a/usage-guides/history/onchain.md
+++ b/usage-guides/history/onchain.md
@@ -1,5 +1,5 @@
 ---
-description: Sending on-chain transactions from rotki via WalletConnect or browser wallet on supported EVM chains.
+description: Send on-chain transactions directly from rotki by connecting a browser wallet or WalletConnect on supported EVM chains, with troubleshooting tips.
 ---
 
 > [!NOTE]

--- a/usage-guides/history/pnl.md
+++ b/usage-guides/history/pnl.md
@@ -1,5 +1,5 @@
 ---
-description: Generating profit/loss reports with FIFO, LIFO, HIFO, or ACB methods and exporting results.
+description: Generate profit/loss reports in rotki using FIFO, LIFO, HIFO, or ACB cost-basis methods, review the cost basis breakdown, and export the results to CSV.
 ---
 
 # Creating a profit/loss report

--- a/usage-guides/index.md
+++ b/usage-guides/index.md
@@ -1,5 +1,5 @@
 ---
-description: Reference for rotki account setup, sign-in, premium sync, data restoration, and upgrading between versions.
+description: "Set up and manage your rotki account: sign-up and sign-in, premium server sync, restoring backups, moving installations, and upgrading between versions."
 ---
 
 # Accounts & Sync

--- a/usage-guides/integrations/calendar.md
+++ b/usage-guides/integrations/calendar.md
@@ -1,5 +1,5 @@
 ---
-description: Using the calendar to track events, set reminders, and receive automatic alerts like ENS expiration.
+description: Use the rotki calendar to add and track events, set reminders for actions, receive automatic alerts such as ENS expiry, and sync with Google Calendar.
 ---
 
 # Calendar

--- a/usage-guides/integrations/exchange-keys.md
+++ b/usage-guides/integrations/exchange-keys.md
@@ -1,5 +1,5 @@
 ---
-description: Connecting centralized exchanges to rotki via API keys, with per-exchange setup instructions.
+description: Connect centralized exchanges to rotki using read-only API keys, with step-by-step setup instructions and exchange-specific notes for each platform.
 ---
 
 # Exchange API Keys

--- a/usage-guides/integrations/external-services.md
+++ b/usage-guides/integrations/external-services.md
@@ -1,5 +1,5 @@
 ---
-description: Configuring external service API keys such as Etherscan, CryptoCompare, and other data providers.
+description: Add external service API keys in rotki such as Etherscan, Blockscout, CryptoCompare, and others to enable on-chain data, prices, and integrations.
 ---
 
 # External Services

--- a/usage-guides/portfolio/accounts.md
+++ b/usage-guides/portfolio/accounts.md
@@ -1,5 +1,5 @@
 ---
-description: Adding and managing blockchain accounts (EVM, Bitcoin, Substrate, Solana) and exchange connections.
+description: Add and manage blockchain accounts across EVM chains, Bitcoin, Substrate, and Solana in rotki, and connect exchanges to track all your balances in one place.
 ---
 
 # Tracking Accounts

--- a/usage-guides/portfolio/balances.md
+++ b/usage-guides/portfolio/balances.md
@@ -1,5 +1,5 @@
 ---
-description: Viewing exchange balances, adding manual balances, tracking NFTs, airdrops, and managing snapshots.
+description: View exchange and manual balances in rotki, track NFTs and airdrops, filter holdings by tags, hide small balances, and capture balance snapshots over time.
 ---
 
 # Balances

--- a/usage-guides/quick-start.md
+++ b/usage-guides/quick-start.md
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step walkthrough to get started with rotki, from installation to generating your first PnL report.
+description: "A step-by-step walkthrough to get started with rotki: install the app, create an account, add accounts, view your portfolio, and generate your first report."
 ---
 
 # Quick Start Guide

--- a/usage-guides/settings/account.md
+++ b/usage-guides/settings/account.md
@@ -1,5 +1,5 @@
 ---
-description: Managing account passwords, database backups, data purging, and user settings import/export.
+description: "Manage rotki account and security settings: change your password, configure database backups, adjust backend options, and purge stored data when needed."
 ---
 
 # Account & Database Settings

--- a/usage-guides/settings/accounting.md
+++ b/usage-guides/settings/accounting.md
@@ -1,5 +1,5 @@
 ---
-description: Configuring accounting rules, cost basis methods, trade settings, and custom event rules for PnL reports.
+description: "Configure rotki's accounting settings: cost basis method, crypto-to-crypto and spending rules, gas costs, tax-free periods, and custom event rules."
 ---
 
 # Accounting Settings

--- a/usage-guides/settings/blockchain.md
+++ b/usage-guides/settings/blockchain.md
@@ -1,5 +1,5 @@
 ---
-description: Configuring EVM chain settings, RPC nodes, transaction indexers, price oracles, and DeFi modules.
+description: Configure rotki's blockchain and EVM settings, including RPC nodes, transaction indexers, price oracle preferences, and which DeFi modules are enabled.
 ---
 
 # Blockchain & EVM Settings

--- a/usage-guides/settings/general.md
+++ b/usage-guides/settings/general.md
@@ -1,5 +1,5 @@
 ---
-description: Configuring general app settings including profit currency, analytics, CSV export, and NFT display options.
+description: Configure rotki's general settings, including your profit currency, application preferences, analytics, CSV export options, and NFT display behavior.
 ---
 
 # General Settings

--- a/usage-guides/settings/interface.md
+++ b/usage-guides/settings/interface.md
@@ -1,5 +1,5 @@
 ---
-description: Customizing the rotki interface including language, theme, animations, balance refresh, and explorer links.
+description: Customize the rotki interface, including language, theme, animations, balance refresh frequency, and blockchain explorer links used across the app.
 ---
 
 # Interface Settings

--- a/usage-guides/staking.md
+++ b/usage-guides/staking.md
@@ -1,5 +1,5 @@
 ---
-description: How to track ETH2 validator staking, Liquity staking, Kraken staking, and Lido CSM node operation in rotki.
+description: Track staking in rotki across ETH2 validators, Liquity, Kraken, and Lido CSM node operation, with per-protocol setup and the rewards each one records.
 ---
 
 # Staking

--- a/usage-guides/statistics.md
+++ b/usage-guides/statistics.md
@@ -1,5 +1,5 @@
 ---
-description: Viewing net value graphs, asset amount/value charts, and balance snapshots with rotki premium.
+description: "Explore rotki premium statistics: net value over time, per-asset amount and value charts, value distribution by location and asset, plus event analysis."
 ---
 
 # Statistics

--- a/usage-guides/tax-accounting/accounting-rules.md
+++ b/usage-guides/tax-accounting/accounting-rules.md
@@ -1,5 +1,5 @@
 ---
-description: Detailed explanation of every accounting setting in rotki including cost basis methods and tax-free periods.
+description: A detailed explanation of every accounting setting in rotki, including cost basis methods, crypto spending, gas costs, and tax-free periods for PnL.
 ---
 
 # Accounting Rule Options Explained

--- a/usage-guides/tax-accounting/event-types.md
+++ b/usage-guides/tax-accounting/event-types.md
@@ -1,5 +1,5 @@
 ---
-description: Complete reference of all event types and subtypes in rotki with examples and default tax treatments.
+description: A complete reference of all event types and subtypes in rotki, with examples, valid combinations, and the default tax treatment applied to each one.
 ---
 
 # Event Types and Subtypes Reference

--- a/usage-guides/tax-accounting/guide.md
+++ b/usage-guides/tax-accounting/guide.md
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step walkthrough for calculating crypto taxes with rotki, from data setup to PnL report generation.
+description: A step-by-step walkthrough for calculating your crypto taxes with rotki, from setting up your data to generating and reviewing a Profit/Loss report.
 ---
 
 # Using rotki for Tax Accounting

--- a/usage-guides/utilities/help.md
+++ b/usage-guides/utilities/help.md
@@ -1,5 +1,5 @@
 ---
-description: Accessing help resources, reporting bugs, and submitting feature requests through the in-app support menu.
+description: Access rotki's help resources, report bugs with logs attached, and submit feature requests directly through the in-app Help & Support menu in the toolbar.
 ---
 
 # Help & Support

--- a/usage-guides/utilities/index.md
+++ b/usage-guides/utilities/index.md
@@ -1,5 +1,5 @@
 ---
-description: Quick-access utilities in rotki including global search, in-app notes, and background task management.
+description: Quick-access utilities in rotki, including global search for fast navigation, taking notes in-app, and monitoring long-running background tasks.
 ---
 
 # Utilities


### PR DESCRIPTION
## Why

Bing's crawler flagged the docs site for three classes of SEO/accessibility issues (see the two `FailingUrls` reports):

1. **Duplicate / triplicate page titles** — the `stable` (`/`), `latest` (`/latest/`), and `patch` (`/patch/`) builds render the same pages with identical `<title>`s across three URL trees.
2. **`/foo` vs `/foo.html` duplicates** — GitHub Pages serves every page at both forms, which the crawler indexes as two distinct, duplicate pages.
3. **Short meta descriptions** — many pages had descriptions under ~100 chars (Bing's short threshold).
4. **Missing image alt** — the VitePress nav logo rendered with an empty `alt` on every page.

## What changed

- **noindex previews** — `latest`/`patch` builds emit `<meta name="robots" content="noindex, follow">` plus a canonical pointing at their stable twin, so the preview trees drop out of the index entirely (consistent with the sitemap already being stable-only).
- **clean URLs + self-canonical** — enable `cleanUrls` so internal links and the sitemap use the extensionless form, and emit a self-referencing canonical on every page (index dirs → `/`). Both `/foo` and `/foo.html` now consolidate to one canonical URL. The `.html` files are still generated, so existing `.html` links keep working (return 200).
- **meta descriptions** — every content page now has a unique description in the recommended ~120–160 char range (the 22 pages Bing flagged, plus a sweep of all remaining short ones and `llms.md` which had none).
- **logo alt** — `logo` is now `{ src: '/logo.png', alt: 'rotki' }`, so the nav logo emits `alt="rotki"`.

## Verification (local build)

- 61 content pages: all have **unique** descriptions, 110–160 chars; none missing/default/duplicate.
- No duplicate `<title>` among real pages.
- Every page self-canonicals to one clean URL; `/foo` and `/foo.html` both return 200 with the same canonical.
- Previews carry `noindex` + canonical→stable.
- 260 built `<img>` tags: **0** with missing/empty alt.
- Every URL in both `FailingUrls` reports re-checked → clean.

## Notes

- `blog.rotki.com` appears in the alt report but is a **separate site**, not this repo — needs fixing wherever the blog lives.
- Warnings won't clear instantly; Bing needs a few recrawl cycles to follow the canonicals and drop the duplicate/preview URLs. Can be nudged via Bing Webmaster Tools.